### PR TITLE
Update for ghc-tcplugin-api v0.7

### DIFF
--- a/large-anon.cabal
+++ b/large-anon.cabal
@@ -31,9 +31,9 @@ library
   other-extensions:
   build-depends:
       -- TODO: Bounds
-      base             >= 4.13  && < 4.14
+      base             >= 4.13  && < 4.18
     , containers
-    , ghc-tcplugin-api >= 0.6.1
+    , ghc-tcplugin-api >= 0.7
     , record-hasfield
     , sop-core
     , text

--- a/src/Data/Record/Anonymous/Plugin/Constraints/RecordConstraints.hs
+++ b/src/Data/Record/Anonymous/Plugin/Constraints/RecordConstraints.hs
@@ -136,7 +136,7 @@ solveRecordConstraints ::
   -> Ct
   -> GenLocated CtLoc CRecordConstraints
   -> TcPluginM 'Solve (Maybe (EvTerm, Ct), [Ct])
-solveRecordConstraints rn@ResolvedNames{..}
+solveRecordConstraints rn
                        orig
                        (L l cr@CRecordConstraints{..})
                      = do

--- a/src/Data/Record/Anonymous/Plugin/GhcTcPluginAPI.hs
+++ b/src/Data/Record/Anonymous/Plugin/GhcTcPluginAPI.hs
@@ -8,54 +8,30 @@
 module Data.Record.Anonymous.Plugin.GhcTcPluginAPI (
     -- * Standard exports
     module GHC.TcPlugin.API
-  , module GHC.Utils.Outputable
+  , module GHC.Builtin.Names
+  , module GHC.Builtin.Types
+  , module GHC.Builtin.Types.Prim
   , module GHC.Core.Make
-
-    -- * Additional re-exports
-
-    -- ** Parsing and constructing types
-  , tyConAppTyCon_maybe
-  , splitAppTy_maybe
-  , isStrLitTy
-  , Boxity(Boxed)
-  , mkStrLitTy
-
-    -- ** Names
-  , showClassName
+  , module GHC.Utils.Outputable
 
     -- * New shims
   , newWanted'
-  , mkUncheckedIntExpr
   ) where
 
 import GHC.TcPlugin.API
-import GHC.TcPlugin.API.Internal (unsafeLiftTcM)
-import GHC.Utils.Outputable
+import GHC.Builtin.Names
+import GHC.Builtin.Types
+import GHC.Builtin.Types.Prim
 import GHC.Core.Make
-
-import BasicTypes (Boxity(Boxed))
-import GhcPlugins (MonadThings(lookupThing), CoreExpr, unsafeGlobalDynFlags)
-import PrelNames (showClassName)
-import Type (tyConAppTyCon_maybe, splitAppTy_maybe, isStrLitTy, mkStrLitTy)
-
-instance ( Monad (TcPluginM s)
-         , MonadTcPlugin (TcPluginM s)
-         ) => MonadThings (TcPluginM s) where
-  lookupThing = unsafeLiftTcM . lookupThing
+import GHC.Utils.Outputable
 
 -- Orphan instance, for debugging
 instance Outputable CtLoc where
   ppr _ = text "<CtLoc>"
 
--- | Construct new wanted constraint
+-- | Construct a new wanted constraint.
 --
--- Work-around bug in ghc, making sure the location is set correctly.
--- TODO: Should this live in ghc-tcplugin-api?
--- (Is it even still needed now that we use the lib, or is this a remnant
--- from the pre-lib days..?)
+-- This works around a bug in GHC, making sure the source location is correct.
+-- See https://gitlab.haskell.org/ghc/ghc/-/issues/20895.
 newWanted' :: CtLoc -> PredType -> TcPluginM 'Solve CtEvidence
 newWanted' l w = setCtLocM l $ newWanted l w
-
-mkUncheckedIntExpr :: Integer -> CoreExpr
-mkUncheckedIntExpr = mkIntExpr unsafeGlobalDynFlags
-

--- a/src/Data/Record/Anonymous/Plugin/NameResolution.hs
+++ b/src/Data/Record/Anonymous/Plugin/NameResolution.hs
@@ -7,7 +7,6 @@ module Data.Record.Anonymous.Plugin.NameResolution (
   ) where
 
 import Data.Record.Anonymous.Plugin.GhcTcPluginAPI
-import PrelNames (knownSymbolClassName)
 
 -- | Names we need to parse constraints or generate core
 --
@@ -17,7 +16,6 @@ data ResolvedNames = ResolvedNames {
     , clsKnownSymbol         :: Class
     , clsRecordConstraints   :: Class
     , clsRecordMetadata      :: Class
-    , clsShow                :: Class
     , dataConDict            :: DataCon
     , dataConFieldLazy       :: DataCon
     , dataConFieldMetadata   :: DataCon
@@ -46,7 +44,6 @@ nameResolution = do
     clsKnownSymbol       <- tcLookupClass knownSymbolClassName
     clsRecordConstraints <- getClass drai "RecordConstraints"
     clsRecordMetadata    <- getClass drai "RecordMetadata"
-    clsShow              <- tcLookupClass showClassName
 
     dataConDict          <- getDataCon dsd "Dict"
     dataConFieldMetadata <- getDataCon drg "FieldMetadata"


### PR DESCRIPTION
This cleans up a few things using version 0.7 of `ghc-tcplugin-api`. I've checked on GHC 8.8, 8.10 and 9.0. (A few too many dependencies needed updating for `9.2`.)